### PR TITLE
build prod fonctionnel

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+ apps: [
+      {
+          name: 'EnSilence',
+          exec_mode: 'cluster',
+          instances: 'max', // Or a number of instances
+          script: './node_modules/nuxt/bin/nuxt.js',
+          args: 'start',
+	  env: {
+	  	"PORT": "6969"
+	  }
+      }
+   ]
+}
+
+

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,11 @@
 export default {
   // Global page headers (https://go.nuxtjs.dev/config-head)
-  head: {
+ 
+ 
+ ssr: false,
+ target: 'static',
+
+ head: {
     title: 'WSDataviz',
     meta: [
       { charset: 'utf-8' },


### PR DESCRIPTION
Fix du build qui marchait pas, avec config pm2 en prime

Pour que ça marche:
- `npm run build`
- `npm run dev`
- `npm run start` ou `pm2 start`